### PR TITLE
Add firestore

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -196,6 +196,14 @@ gcloud secrets versions access latest --secret=<ES_CERT_SECRET_ID> --out-file=/t
 curl --cacert /tmp/es_ca.crt -u "<ES_USERNAME>:$(gcloud secrets versions access latest --secret=<ES_PASSWORD_SECRET_ID>)" <ES_PROTO>://<ES_DNS_NAME>:<ES_PORT>
 ```
 
+#### Firestore
+
+From bastion host / debug pod:
+
+```shell
+gcloud firestore databases list
+```
+
 ## Troubleshooting
 
 ### Resource already being used when executing `terraform destroy`
@@ -278,9 +286,12 @@ Terraform's Google provider is configured to use default `gcloud` credentials. I
 | [google_compute_router.group1](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_router) | resource |
 | [google_dns_managed_zone.internal-zone](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dns_managed_zone) | resource |
 | [google_dns_record_set.elsasticsearch](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dns_record_set) | resource |
+| [google_firestore_database.database](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/firestore_database) | resource |
 | [google_managed_kafka_cluster.kafka](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/managed_kafka_cluster) | resource |
 | [google_managed_kafka_topic.dummy](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/managed_kafka_topic) | resource |
 | [google_project_iam_binding.bastion_service_account_iam_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_binding) | resource |
+| [google_project_iam_binding.firestore_service_account_iam_binding_bastion](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_binding) | resource |
+| [google_project_iam_binding.firestore_service_account_iam_binding_gke](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_binding) | resource |
 | [google_project_iam_binding.gke_iam_workflow_identity_iam_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_binding) | resource |
 | [google_project_iam_binding.gke_ingress_controller_iam_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_binding) | resource |
 | [google_project_iam_binding.kafka_service_account_iam_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_binding) | resource |
@@ -351,6 +362,7 @@ Terraform's Google provider is configured to use default `gcloud` credentials. I
 | <a name="output_elasticsearch_root_password"></a> [elasticsearch\_root\_password](#output\_elasticsearch\_root\_password) | n/a |
 | <a name="output_elasticsearch_root_password_secret_id"></a> [elasticsearch\_root\_password\_secret\_id](#output\_elasticsearch\_root\_password\_secret\_id) | n/a |
 | <a name="output_elasticsearch_root_username"></a> [elasticsearch\_root\_username](#output\_elasticsearch\_root\_username) | n/a |
+| <a name="output_firestore_db_name"></a> [firestore\_db\_name](#output\_firestore\_db\_name) | n/a |
 | <a name="output_gke_cluster_dns_endpoint"></a> [gke\_cluster\_dns\_endpoint](#output\_gke\_cluster\_dns\_endpoint) | n/a |
 | <a name="output_gke_cluster_endpoint"></a> [gke\_cluster\_endpoint](#output\_gke\_cluster\_endpoint) | n/a |
 | <a name="output_gke_cluster_name"></a> [gke\_cluster\_name](#output\_gke\_cluster\_name) | n/a |

--- a/terraform/firestore.tf
+++ b/terraform/firestore.tf
@@ -1,0 +1,6 @@
+resource "google_firestore_database" "database" {
+  project     = local.gcp_project_id
+  name        = "ersms"
+  location_id = local.gcp_region
+  type        = "FIRESTORE_NATIVE"
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -33,6 +33,30 @@ resource "google_project_iam_binding" "kafka_service_account_iam_binding" {
   ]
 }
 
+resource "google_project_iam_binding" "firestore_service_account_iam_binding_gke" {
+  for_each = toset([
+    "roles/datastore.user"
+  ])
+  project = local.gcp_project_id
+  role    = each.value
+
+  members = [
+    google_service_account.gke_pod_identity.member
+  ]
+}
+
+resource "google_project_iam_binding" "firestore_service_account_iam_binding_bastion" {
+  for_each = toset([
+    "roles/datastore.owner"
+  ])
+  project = local.gcp_project_id
+  role    = each.value
+
+  members = [
+    google_service_account.bastion_service_account.member,
+  ]
+}
+
 resource "google_service_account" "elasticsearch_service_account" {
   account_id   = "${local.prfx}elasticsearch"
   display_name = "ElasticSearch"

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -134,3 +134,11 @@ output "elasticsearch_caceret_secret_id" {
 output "storage_k8s_manifests_bucket_url" {
   value = google_storage_bucket.k8s_manifests.url
 }
+
+#############
+# Firestore #
+#############
+
+output "firestore_db_name" {
+  value = google_firestore_database.database.name
+}

--- a/terraform/setup.sh
+++ b/terraform/setup.sh
@@ -59,7 +59,8 @@ heading "Enabling APIs..."
         cloudresourcemanager.googleapis.com \
         dns.googleapis.com \
         iamcredentials.googleapis.com \
-        secretmanager.googleapis.com
+        secretmanager.googleapis.com \
+        firestore.googleapis.com
 )
 
 heading "Initializing terraform..."


### PR DESCRIPTION
**What?**
- Add firestore to TF

**Why?**
- Forgor

**How?**
- Added to TF, single `ersms` DB is created, debug pod is granted `roles/datastore.user` persmissions and bastion is granted `roles/datastore.owner`

**Testing**

![obraz](https://github.com/user-attachments/assets/49aca43f-792f-4168-85f6-05c77eda6f1d)
